### PR TITLE
rm s3daemon::instance::s3_endpoint_url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ s3daemon::env:
   AWS_CA_BUNDLE: /path/to/cacert.pem
 s3daemon::instances:
   foo:
-    s3_endpoint_url: https://s3.foo.example.com
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
     port: 15556
     image: ghcr.io/lsst-dm/s3daemon:main
+    env:
+      S3_ENDPOINT_URL: https://s3.foo.example.com
   bar:
-    s3_endpoint_url: https://s3.bar.example.com
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
     port: 15557
@@ -49,6 +49,7 @@ s3daemon::instances:
       - "/home:/home"
       - "/opt:/opt"
     env:
+      S3_ENDPOINT_URL: https://s3.bar.example.com
       AWS_DEFAULT_REGION: baz
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,19 +54,12 @@ Deploy the s3daemon service
 
 The following parameters are available in the `s3daemon::instance` defined type:
 
-* [`s3_endpoint_url`](#-s3daemon--instance--s3_endpoint_url)
 * [`aws_access_key_id`](#-s3daemon--instance--aws_access_key_id)
 * [`aws_secret_access_key`](#-s3daemon--instance--aws_secret_access_key)
 * [`port`](#-s3daemon--instance--port)
 * [`image`](#-s3daemon--instance--image)
 * [`volumes`](#-s3daemon--instance--volumes)
 * [`env`](#-s3daemon--instance--env)
-
-##### <a name="-s3daemon--instance--s3_endpoint_url"></a>`s3_endpoint_url`
-
-Data type: `Stdlib::HTTPUrl`
-
-The URL of the S3 endpoint to which the s3daemon service will send files.
 
 ##### <a name="-s3daemon--instance--aws_access_key_id"></a>`aws_access_key_id`
 

--- a/examples/instances.pp
+++ b/examples/instances.pp
@@ -4,22 +4,24 @@ class { 's3daemon':
   },
   instances => {
     'foo' => {
-      's3_endpoint_url'       => 'https://s3.foo.example.com',
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
       'port'                  => 15556,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:main',
+      'env'                   => {
+        'S3_ENDPOINT_URL' => 'https://s3.foo.example.com',
+        'FOO'             => 'bar',
+      },
     },
     'bar' => {
-      's3_endpoint_url'       => 'https://s3.bar.example.com',
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
       'port'                  => 15557,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:sha-b5e72fa',
       'volumes'               => ['/home:/home', '/opt:/opt'],
       'env'                   => {
-        'FOO' => 'bar',
-        'BAZ' => 'qux',
+        'S3_ENDPOINT_URL' => 'https://s3.bar.example.com',
+        'BAZ'             => 'qux',
       },
     },
   },

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,9 +1,6 @@
 # @summary
 #   Deploy the s3daemon service
 #
-# @param s3_endpoint_url
-#   The URL of the S3 endpoint to which the s3daemon service will send files.
-#
 # @param aws_access_key_id
 #   The AWS access key ID to use for authentication.
 #
@@ -24,7 +21,6 @@
 #  A hash of additional environment variables to set in the container.
 #
 define s3daemon::instance (
-  Stdlib::HTTPUrl $s3_endpoint_url,
   Variant[String[1], Sensitive[String[1]]] $aws_access_key_id,
   Variant[String[1], Sensitive[String[1]]] $aws_secret_access_key,
   Stdlib::Port $port = 15556,
@@ -34,7 +30,6 @@ define s3daemon::instance (
 ) {
   $envvars = {
     'S3DAEMON_PORT'         => $port,
-    'S3_ENDPOINT_URL'       => $s3_endpoint_url,
     'AWS_ACCESS_KEY_ID'     => $aws_access_key_id.unwrap,
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
   } + $s3daemon::env + $env

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -19,6 +19,7 @@ describe 's3daemon' do
         it { is_expected.to contain 'AWS_ACCESS_KEY_ID=access_key_id' }
         it { is_expected.to contain 'AWS_SECRET_ACCESS_KEY=secret_access_key' }
         it { is_expected.to contain 'QUUX=corge' }
+        it { is_expected.to contain 'FOO=bar' }
       end
 
       describe docker_container('systemd-s3daemon-foo') do
@@ -49,9 +50,8 @@ describe 's3daemon' do
         it { is_expected.to contain 'S3_ENDPOINT_URL=https://s3.bar.example.com' }
         it { is_expected.to contain 'AWS_ACCESS_KEY_ID=access_key_id' }
         it { is_expected.to contain 'AWS_SECRET_ACCESS_KEY=secret_access_key' }
-        it { is_expected.to contain 'FOO=bar' }
-        it { is_expected.to contain 'BAZ=qux' }
         it { is_expected.to contain 'QUUX=corge' }
+        it { is_expected.to contain 'BAZ=qux' }
       end
 
       describe docker_container('systemd-s3daemon-bar') do

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -9,7 +9,9 @@ describe 's3daemon::instance' do
       let(:title) { 'foo' }
       let(:params) do
         {
-          s3_endpoint_url: 'https://s3.example.com',
+          env: {
+            S3_ENDPOINT_URL: 'https://s3.example.com',
+          },
           aws_access_key_id: 'foo',
           aws_secret_access_key: 'bar',
         }


### PR DESCRIPTION
This param creates an env var in the container and the hardcoded
behavior prevents the env var from being renamed by the implementation.