### PR TITLE
rm s3daemon::instance::port param

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ s3daemon::instances:
   foo:
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
-    port: 15556
     image: ghcr.io/lsst-dm/s3daemon:main
     env:
       S3_ENDPOINT_URL: https://s3.foo.example.com
+      S3DAEMON_PORT: 15556
   bar:
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
-    port: 15557
     image: ghcr.io/lsst-dm/s3daemon:sha-b5e72fa
     volumes:
       - "/home:/home"
       - "/opt:/opt"
     env:
       S3_ENDPOINT_URL: https://s3.bar.example.com
+      S3DAEMON_PORT: 15557
       AWS_DEFAULT_REGION: baz
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ s3daemon::env:
   AWS_CA_BUNDLE: /path/to/cacert.pem
 s3daemon::instances:
   foo:
-    s3_endpoint_url: https://s3.foo.example.com
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
     port: 15556
     image: ghcr.io/lsst-dm/s3daemon:main
+    env:
+      S3_ENDPOINT_URL: https://s3.foo.example.com
   bar:
-    s3_endpoint_url: https://s3.bar.example.com
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
     port: 15557
@@ -49,6 +49,7 @@ s3daemon::instances:
       - "/home:/home"
       - "/opt:/opt"
     env:
+      S3_ENDPOINT_URL: https://s3.bar.example.com
       AWS_DEFAULT_REGION: baz
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ lookup_options:
       strategy: deep
 classes:
   - s3daemon
+s3daemon::env:
+  AWS_CA_BUNDLE: /path/to/cacert.pem
 s3daemon::instances:
   foo:
     s3_endpoint_url: https://s3.foo.example.com
@@ -46,6 +48,8 @@ s3daemon::instances:
     volumes:
       - "/home:/home"
       - "/opt:/opt"
+    env:
+      AWS_DEFAULT_REGION: baz
 ```
 
 ## Reference

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,19 +54,12 @@ Deploy the s3daemon service
 
 The following parameters are available in the `s3daemon::instance` defined type:
 
-* [`s3_endpoint_url`](#-s3daemon--instance--s3_endpoint_url)
 * [`aws_access_key_id`](#-s3daemon--instance--aws_access_key_id)
 * [`aws_secret_access_key`](#-s3daemon--instance--aws_secret_access_key)
 * [`port`](#-s3daemon--instance--port)
 * [`image`](#-s3daemon--instance--image)
 * [`volumes`](#-s3daemon--instance--volumes)
 * [`env`](#-s3daemon--instance--env)
-
-##### <a name="-s3daemon--instance--s3_endpoint_url"></a>`s3_endpoint_url`
-
-Data type: `Stdlib::HTTPUrl`
-
-The URL of the S3 endpoint to which the s3daemon service will send files.
 
 ##### <a name="-s3daemon--instance--aws_access_key_id"></a>`aws_access_key_id`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,7 +56,6 @@ The following parameters are available in the `s3daemon::instance` defined type:
 
 * [`aws_access_key_id`](#-s3daemon--instance--aws_access_key_id)
 * [`aws_secret_access_key`](#-s3daemon--instance--aws_secret_access_key)
-* [`port`](#-s3daemon--instance--port)
 * [`image`](#-s3daemon--instance--image)
 * [`volumes`](#-s3daemon--instance--volumes)
 * [`env`](#-s3daemon--instance--env)
@@ -72,14 +71,6 @@ The AWS access key ID to use for authentication.
 Data type: `Variant[String[1], Sensitive[String[1]]]`
 
 The AWS secret access key to use for authentication.
-
-##### <a name="-s3daemon--instance--port"></a>`port`
-
-Data type: `Stdlib::Port`
-
-The tcp port on which the s3daemon service will listen.
-
-Default value: `15556`
 
 ##### <a name="-s3daemon--instance--image"></a>`image`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,6 +23,7 @@ Client/server for pushing objects to S3 storage.
 The following parameters are available in the `s3daemon` class:
 
 * [`instances`](#-s3daemon--instances)
+* [`env`](#-s3daemon--env)
 
 ##### <a name="-s3daemon--instances"></a>`instances`
 
@@ -32,6 +33,16 @@ A hash of instances to configure. The key is the instance name and the value
 is a hash of `s3daemon::instance` parameters.
 
 Default value: `undef`
+
+##### <a name="-s3daemon--env"></a>`env`
+
+Data type: `Hash`
+
+A hash of additional environment variables to set in the container, common
+to all s3daemon::instance(s) but may be overridden by the instance's env
+param.
+
+Default value: `{}`
 
 ## Defined types
 

--- a/examples/instances.pp
+++ b/examples/instances.pp
@@ -1,28 +1,26 @@
 class { 's3daemon':
   env       => {
-    'QUUX' => 'corge',
+    'S3DAEMON_PORT' => 15556,
+    'QUUX'          => 'corge',
   },
   instances => {
     'foo' => {
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
-      'port'                  => 15556,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:main',
       'env'                   => {
         'S3_ENDPOINT_URL' => 'https://s3.foo.example.com',
         'FOO'             => 'bar',
-        'BAZ'             => 'qux',
       },
     },
     'bar' => {
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
-      'port'                  => 15557,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:sha-b5e72fa',
       'volumes'               => ['/home:/home', '/opt:/opt'],
       'env'                   => {
         'S3_ENDPOINT_URL' => 'https://s3.bar.example.com',
-        'FOO'             => 'bar',
+        'S3DAEMON_PORT'   => 15557,
         'BAZ'             => 'qux',
       },
     },

--- a/examples/instances.pp
+++ b/examples/instances.pp
@@ -4,22 +4,26 @@ class { 's3daemon':
   },
   instances => {
     'foo' => {
-      's3_endpoint_url'       => 'https://s3.foo.example.com',
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
       'port'                  => 15556,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:main',
+      'env'                   => {
+        'S3_ENDPOINT_URL' => 'https://s3.foo.example.com',
+        'FOO'             => 'bar',
+        'BAZ'             => 'qux',
+      },
     },
     'bar' => {
-      's3_endpoint_url'       => 'https://s3.bar.example.com',
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
       'port'                  => 15557,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:sha-b5e72fa',
       'volumes'               => ['/home:/home', '/opt:/opt'],
       'env'                   => {
-        'FOO' => 'bar',
-        'BAZ' => 'qux',
+        'S3_ENDPOINT_URL' => 'https://s3.bar.example.com',
+        'FOO'             => 'bar',
+        'BAZ'             => 'qux',
       },
     },
   },

--- a/examples/instances.pp
+++ b/examples/instances.pp
@@ -1,4 +1,7 @@
 class { 's3daemon':
+  env       => {
+    'QUUX' => 'corge',
+  },
   instances => {
     'foo' => {
       's3_endpoint_url'       => 'https://s3.foo.example.com',
@@ -16,7 +19,7 @@ class { 's3daemon':
       'volumes'               => ['/home:/home', '/opt:/opt'],
       'env'                   => {
         'FOO' => 'bar',
-        'BAZ' => 'quix',
+        'BAZ' => 'qux',
       },
     },
   },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,14 @@
 #   A hash of instances to configure. The key is the instance name and the value
 #   is a hash of `s3daemon::instance` parameters.
 #
+# @param env
+#  A hash of additional environment variables to set in the container, common
+#  to all s3daemon::instance(s) but may be overridden by the instance's env
+#  param.
+#
 class s3daemon (
-  Optional[Hash[String[1], Hash]] $instances = undef
+  Optional[Hash[String[1], Hash]] $instances = undef,
+  Hash $env = {},
 ) {
   if $instances != undef {
     $instances.each |$name, $params| {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -7,9 +7,6 @@
 # @param aws_secret_access_key
 #   The AWS secret access key to use for authentication.
 #
-# @param port
-#   The tcp port on which the s3daemon service will listen.
-#
 # @param image
 #   The container image to use for the s3daemon service.
 #
@@ -23,13 +20,11 @@
 define s3daemon::instance (
   Variant[String[1], Sensitive[String[1]]] $aws_access_key_id,
   Variant[String[1], Sensitive[String[1]]] $aws_secret_access_key,
-  Stdlib::Port $port = 15556,
   String[1] $image = 'ghcr.io/lsst-dm/s3daemon:main',
   Array[Stdlib::Absolutepath] $volumes = ['/home:/home'],
   Hash $env = {},
 ) {
   $envvars = {
-    'S3DAEMON_PORT'         => $port,
     'AWS_ACCESS_KEY_ID'     => $aws_access_key_id.unwrap,
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
   } + $s3daemon::env + $env

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,9 +1,6 @@
 # @summary
 #   Deploy the s3daemon service
 #
-# @param s3_endpoint_url
-#   The URL of the S3 endpoint to which the s3daemon service will send files.
-#
 # @param aws_access_key_id
 #   The AWS access key ID to use for authentication.
 #
@@ -24,7 +21,6 @@
 #  A hash of additional environment variables to set in the container.
 #
 define s3daemon::instance (
-  Stdlib::HTTPUrl $s3_endpoint_url,
   Variant[String[1], Sensitive[String[1]]] $aws_access_key_id,
   Variant[String[1], Sensitive[String[1]]] $aws_secret_access_key,
   Stdlib::Port $port = 15556,
@@ -34,7 +30,6 @@ define s3daemon::instance (
 ) {
   $envvars = {
     'S3DAEMON_PORT'         => $port,
-    'S3_ENDPOINT_URL'       => $s3_endpoint_url,
     'AWS_ACCESS_KEY_ID'     => $aws_access_key_id.unwrap,
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
   } + $s3daemon::env + $env

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -37,7 +37,7 @@ define s3daemon::instance (
     'S3_ENDPOINT_URL'       => $s3_endpoint_url,
     'AWS_ACCESS_KEY_ID'     => $aws_access_key_id.unwrap,
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
-  } + $env
+  } + $s3daemon::env + $env
 
   file { "/etc/sysconfig/s3daemon-${name}":
     ensure    => file,

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -18,6 +18,7 @@ describe 's3daemon' do
         it { is_expected.to contain 'S3_ENDPOINT_URL=https://s3.foo.example.com' }
         it { is_expected.to contain 'AWS_ACCESS_KEY_ID=access_key_id' }
         it { is_expected.to contain 'AWS_SECRET_ACCESS_KEY=secret_access_key' }
+        it { is_expected.to contain 'QUUX=corge' }
       end
 
       describe docker_container('systemd-s3daemon-foo') do
@@ -49,7 +50,8 @@ describe 's3daemon' do
         it { is_expected.to contain 'AWS_ACCESS_KEY_ID=access_key_id' }
         it { is_expected.to contain 'AWS_SECRET_ACCESS_KEY=secret_access_key' }
         it { is_expected.to contain 'FOO=bar' }
-        it { is_expected.to contain 'BAZ=quix' }
+        it { is_expected.to contain 'BAZ=qux' }
+        it { is_expected.to contain 'QUUX=corge' }
       end
 
       describe docker_container('systemd-s3daemon-bar') do

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -9,7 +9,9 @@ describe 's3daemon::instance' do
       let(:title) { 'foo' }
       let(:params) do
         {
-          s3_endpoint_url: 'https://s3.example.com',
+          env: {
+            S3_ENDPOINT_URL: 'https://s3.example.com',
+          },
           aws_access_key_id: 'foo',
           aws_secret_access_key: 'bar',
         }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -11,6 +11,7 @@ describe 's3daemon::instance' do
         {
           env: {
             S3_ENDPOINT_URL: 'https://s3.example.com',
+            S3DAEMON_PORT: 15_556,
           },
           aws_access_key_id: 'foo',
           aws_secret_access_key: 'bar',

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -14,6 +14,11 @@ describe 's3daemon::instance' do
           aws_secret_access_key: 'bar',
         }
       end
+      let(:pre_condition) do
+        <<-PRE_CONDITION
+          include s3daemon
+        PRE_CONDITION
+      end
 
       it { is_expected.to compile.with_all_deps }
 
@@ -47,12 +52,62 @@ describe 's3daemon::instance' do
         )
       end
 
-      context 'with env' do
+      context 'with instance env' do
         let(:params) do
           super().merge(
             env: {
               'FOO' => 'BAR',
             }
+          )
+        end
+
+        it do
+          is_expected.to contain_file("/etc/sysconfig/s3daemon-#{title}").with(
+            content: %r{FOO=BAR}
+          )
+        end
+      end
+
+      context 'with s3daemon::env' do
+        let(:pre_condition) do
+          <<-PRE_CONDITION
+            class { 's3daemon':
+              env => {
+                'BAZ' => 'QUX',
+              },
+            }
+          PRE_CONDITION
+        end
+
+        it do
+          is_expected.to contain_file("/etc/sysconfig/s3daemon-#{title}").with(
+            content: %r{BAZ=QUX}
+          )
+        end
+      end
+
+      context 'with s3daemon::env & isntance env' do
+        let(:pre_condition) do
+          <<-PRE_CONDITION
+            class { 's3daemon':
+              env => {
+                'BAZ' => 'QUX',
+              },
+            }
+          PRE_CONDITION
+        end
+
+        let(:params) do
+          super().merge(
+            env: {
+              'FOO' => 'BAR',
+            }
+          )
+        end
+
+        it do
+          is_expected.to contain_file("/etc/sysconfig/s3daemon-#{title}").with(
+            content: %r{BAZ=QUX}
           )
         end
 


### PR DESCRIPTION
This param creates an env var in the container and the hardcoded
behavior prevents the env var from being renamed by the implementation.