### PR TITLE
rm s3daemon::instance::port param

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ s3daemon::instances:
   foo:
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
-    port: 15556
     image: ghcr.io/lsst-dm/s3daemon:main
     env:
       S3_ENDPOINT_URL: https://s3.foo.example.com
+      S3DAEMON_PORT: 15556
   bar:
     aws_access_key_id: access_key_id
     aws_secret_access_key: secret_access_key
-    port: 15557
     image: ghcr.io/lsst-dm/s3daemon:sha-b5e72fa
     volumes:
       - "/home:/home"
       - "/opt:/opt"
     env:
       S3_ENDPOINT_URL: https://s3.bar.example.com
+      S3DAEMON_PORT: 15557
       AWS_DEFAULT_REGION: baz
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,7 +56,6 @@ The following parameters are available in the `s3daemon::instance` defined type:
 
 * [`aws_access_key_id`](#-s3daemon--instance--aws_access_key_id)
 * [`aws_secret_access_key`](#-s3daemon--instance--aws_secret_access_key)
-* [`port`](#-s3daemon--instance--port)
 * [`image`](#-s3daemon--instance--image)
 * [`volumes`](#-s3daemon--instance--volumes)
 * [`env`](#-s3daemon--instance--env)
@@ -72,14 +71,6 @@ The AWS access key ID to use for authentication.
 Data type: `Variant[String[1], Sensitive[String[1]]]`
 
 The AWS secret access key to use for authentication.
-
-##### <a name="-s3daemon--instance--port"></a>`port`
-
-Data type: `Stdlib::Port`
-
-The tcp port on which the s3daemon service will listen.
-
-Default value: `15556`
 
 ##### <a name="-s3daemon--instance--image"></a>`image`
 

--- a/examples/instances.pp
+++ b/examples/instances.pp
@@ -1,12 +1,12 @@
 class { 's3daemon':
   env       => {
-    'QUUX' => 'corge',
+    'S3DAEMON_PORT' => 15556,
+    'QUUX'          => 'corge',
   },
   instances => {
     'foo' => {
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
-      'port'                  => 15556,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:main',
       'env'                   => {
         'S3_ENDPOINT_URL' => 'https://s3.foo.example.com',
@@ -16,11 +16,11 @@ class { 's3daemon':
     'bar' => {
       'aws_access_key_id'     => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
-      'port'                  => 15557,
       'image'                 => 'ghcr.io/lsst-dm/s3daemon:sha-b5e72fa',
       'volumes'               => ['/home:/home', '/opt:/opt'],
       'env'                   => {
         'S3_ENDPOINT_URL' => 'https://s3.bar.example.com',
+        'S3DAEMON_PORT'   => 15557,
         'BAZ'             => 'qux',
       },
     },

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -7,9 +7,6 @@
 # @param aws_secret_access_key
 #   The AWS secret access key to use for authentication.
 #
-# @param port
-#   The tcp port on which the s3daemon service will listen.
-#
 # @param image
 #   The container image to use for the s3daemon service.
 #
@@ -23,13 +20,11 @@
 define s3daemon::instance (
   Variant[String[1], Sensitive[String[1]]] $aws_access_key_id,
   Variant[String[1], Sensitive[String[1]]] $aws_secret_access_key,
-  Stdlib::Port $port = 15556,
   String[1] $image = 'ghcr.io/lsst-dm/s3daemon:main',
   Array[Stdlib::Absolutepath] $volumes = ['/home:/home'],
   Hash $env = {},
 ) {
   $envvars = {
-    'S3DAEMON_PORT'         => $port,
     'AWS_ACCESS_KEY_ID'     => $aws_access_key_id.unwrap,
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
   } + $s3daemon::env + $env

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -11,6 +11,7 @@ describe 's3daemon::instance' do
         {
           env: {
             S3_ENDPOINT_URL: 'https://s3.example.com',
+            S3DAEMON_PORT: 15_556,
           },
           aws_access_key_id: 'foo',
           aws_secret_access_key: 'bar',


### PR DESCRIPTION
This param creates an env var in the container and the hardcoded
behavior prevents the env var from being renamed by the implementation.