### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v2.0.0](https://github.com/lsst-it/puppet-s3daemon/tree/v2.0.0) (2025-05-14)
+
+[Full Changelog](https://github.com/lsst-it/puppet-s3daemon/compare/v1.2.0...v2.0.0)
+
+**Breaking changes:**
+
+- rm s3daemon::instance::port param [\#18](https://github.com/lsst-it/puppet-s3daemon/pull/18) ([jhoblitt](https://github.com/jhoblitt))
+- rm s3daemon::instance::s3\_endpoint\_url param [\#15](https://github.com/lsst-it/puppet-s3daemon/pull/15) ([jhoblitt](https://github.com/jhoblitt))
+
+**Implemented enhancements:**
+
+- add s3daemon::image param [\#19](https://github.com/lsst-it/puppet-s3daemon/pull/19) ([jhoblitt](https://github.com/jhoblitt))
+- add s3daemon::env param [\#9](https://github.com/lsst-it/puppet-s3daemon/pull/9) ([jhoblitt](https://github.com/jhoblitt))
+
 ## [v1.2.0](https://github.com/lsst-it/puppet-s3daemon/tree/v1.2.0) (2024-11-13)
 
 [Full Changelog](https://github.com/lsst-it/puppet-s3daemon/compare/v1.1.0...v1.2.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-s3daemon",
-  "version": "1.2.1-rc0",
+  "version": "2.0.0",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "Client/server for pushing objects to S3 storage.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit 4c94bff197f883b9e4fb7bf05784b5c353353b78.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).