### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v2.1.0](https://github.com/lsst-it/puppet-s3daemon/tree/v2.1.0) (2025-05-30)
+
+[Full Changelog](https://github.com/lsst-it/puppet-s3daemon/compare/v2.0.0...v2.1.0)
+
+**Implemented enhancements:**
+
+- add s3daemon::volumes param [\#21](https://github.com/lsst-it/puppet-s3daemon/pull/21) ([jhoblitt](https://github.com/jhoblitt))
+
 ## [v2.0.0](https://github.com/lsst-it/puppet-s3daemon/tree/v2.0.0) (2025-05-14)
 
 [Full Changelog](https://github.com/lsst-it/puppet-s3daemon/compare/v1.2.0...v2.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-s3daemon",
-  "version": "2.0.1-rc0",
+  "version": "2.1.0",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "Client/server for pushing objects to S3 storage.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit b3ecf01d27b45e84d8ce8ccf4ab26220f0242534.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).